### PR TITLE
Add comprehensive documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,139 @@
+# Global Ocean Observing System Mock Dashboard
+
+The **GOOS Dashboard** is a Vite-powered React application that visualises a fictional environmental monitoring feed for underwater settlement scenarios. It was originally built for a mock trial exercise where students examine impacts of industrial activity on marine ecosystems. All figures are procedurally generated to create a convincing narrative while remaining safe for classroom use.
+
+The goal of this repository is to supply everything you need to run, present, and extend the dashboard experience. This documentation covers project layout, data generation, live collaboration features, and guidance for adapting the visuals to your own story.
+
+## Features at a Glance
+
+- 📊 **Comprehensive analytics** – Ten chart-based exhibits (line, bar, radar, and doughnut) summarise toxin trends, water usage, biomass, reef health, energy mix, and more.
+- 🌍 **Scenario switching** – Toggle between Baseline, Mitigation, and Rapid Expansion narratives to explore divergent futures.
+- 🎚️ **Presenter controls** – A `/controls` route exposes a remote control surface with shared state broadcasting for live demos.
+- 🌓 **Dynamic theming** – Dark/light themes are persisted locally and sync across participants.
+- 🔄 **Procedural data** – Deterministic pseudo-random generation keeps the story consistent while allowing variance with a "Randomize Mock Data" button.
+
+## Repository Layout
+
+```
+COMPSGN490-Project2/
+├── README.md                # You are here!
+├── docs/                    # Additional in-depth documentation
+└── mock_dashboard/          # Vite project root
+    ├── index.html
+    ├── package.json
+    ├── src/
+    │   ├── App.jsx          # All application logic and React components
+    │   ├── main.jsx         # React entry point
+    │   ├── styles.css       # Theme tokens and layout rules
+    │   └── assets/
+    │       └── risk-map.png # Background texture for the risk map
+    └── vite.config.js
+```
+
+Each topic receives deeper treatment inside the [`docs/`](docs) directory:
+
+- [`architecture.md`](docs/architecture.md) explains component composition, routing, and state management.
+- [`data-scenarios.md`](docs/data-scenarios.md) documents how synthetic metrics are produced and scaled.
+- [`presenter-mode.md`](docs/presenter-mode.md) outlines how to share control between multiple viewers.
+- [`style-guide.md`](docs/style-guide.md) highlights CSS tokens and how to retheme the experience.
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) **18.x or 20.x** (Vite 5 requires an actively supported LTS release).
+- npm (bundled with Node). Yarn and pnpm work as well if you adapt the commands.
+
+### Install dependencies
+
+```bash
+cd mock_dashboard
+npm install
+```
+
+### Run the development server
+
+```bash
+npm run dev
+```
+
+Vite prints a local URL (for example `http://localhost:5173/`). Open it in your browser to explore the dashboard. Hot Module Replacement keeps the view in sync with any code or style edits.
+
+### Build for production
+
+```bash
+npm run build
+```
+
+The command outputs a fully static bundle in `mock_dashboard/dist`. Use `npm run preview` to verify the production build locally.
+
+### Lint the project
+
+```bash
+npm run lint
+```
+
+ESLint checks JSX and hook usage. Address any warnings before committing classroom modifications.
+
+## Application Scripts
+
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Launches Vite dev server with hot reloading. |
+| `npm run build` | Creates an optimized production bundle. |
+| `npm run preview` | Serves the production build locally for verification. |
+| `npm run lint` | Runs ESLint with the React, Hooks, and Refresh plugins. |
+
+## High-Level Architecture
+
+At runtime, `src/main.jsx` mounts the `<App />` component inside a React Router `<BrowserRouter>`. The application exposes two routes:
+
+- `/` renders the primary dashboard view with charts, watchlists, and an incident timeline.
+- `/controls` renders a presenter console that manipulates the same application state (region, year, scenario, theme, and random seed).
+
+The central `App.jsx` file contains:
+
+- Scenario definitions, baseline datasets, and helper utilities for deterministic randomisation.
+- `generateDashboardData` – builds all derived metrics (toxins, temperatures, biomass, reef health, etc.) based on the current filters.
+- `buildChartConfigs` – prepares Chart.js configuration objects for each visualisation.
+- React components for KPI cards, map overlays, watchlists, and charts.
+- Live collaboration hooks that optionally subscribe to `/api/stream` (Server-Sent Events) and broadcast state changes to `/api/controls`.
+
+Review [`docs/architecture.md`](docs/architecture.md) for a component-by-component breakdown.
+
+## Data Generation Overview
+
+All dashboard numbers are fictitious but coherent. A seeded pseudo-random generator (`mulberry32`) allows the same filters to produce stable outputs, while reseeding through the "Randomize Mock Data" button yields plausible variants. `generateDashboardData` derives values for toxins, temperatures, fish biomass, reef health, desalination usage, atmospheric gases, occupancy, energy mix, and a watchlist of at-risk sites.
+
+Scenarios influence data through multiplicative and additive factors, enabling consistent storytelling:
+
+- **Baseline** keeps metrics close to the seed data.
+- **Mitigation** rewards sustainable policies (higher fish biomass, healthier reefs, lower toxins).
+- **Rapid Expansion** stresses the system (elevated toxins, higher CO₂, heavier desalination draw).
+
+The [data reference](docs/data-scenarios.md) documents each field and how the modifiers are applied.
+
+## Presenter Workflow
+
+The dashboard is designed for collaborative presentations:
+
+1. Open the main dashboard in a classroom display (route `/`).
+2. On a secondary device, navigate to `/controls` to adjust scenario settings.
+3. When the hosting environment implements the optional `/api/stream` and `/api/controls` endpoints, changes sync live via Server-Sent Events and `fetch` updates. Otherwise, the controls still work locally without remote broadcast.
+
+Detailed presenter tips and recommended setups live in [`docs/presenter-mode.md`](docs/presenter-mode.md).
+
+## Customisation Tips
+
+- **Theming** – Toggle between dark/light modes or edit the CSS custom properties in `styles.css`. The [style guide](docs/style-guide.md) explains the available tokens.
+- **Charts** – Update labels, tooltips, or Chart.js options inside `buildChartConfigs`.
+- **Narrative** – Modify `SCENARIO_INFO`, `WATCHLIST_BASE`, or the static copy blocks to match your storyline.
+- **Assets** – Replace `risk-map.png` with your own background to change the look of the risk heatmap.
+
+## Contributing
+
+Issues and pull requests are welcome for documentation, visual polish, or data tweaks. Please run `npm run lint` before submitting changes.
+
+## License
+
+This project is released for educational purposes. Adapt freely for classroom demos and cite the original assignment where appropriate.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,68 @@
+# Application Architecture
+
+This document describes how the GOOS Dashboard React application is assembled. Use it as a companion while exploring `src/App.jsx` and related files.
+
+## Bootstrapping
+
+`src/main.jsx` mounts the root `<App />` component within a `BrowserRouter`, ensuring client-side routing for the dashboard and the presenter controls. Global styles from `styles.css` are imported here so they apply before any components render.
+
+Chart.js elements required by the visualisations (line, bar, radar, doughnut) are registered at the top of `App.jsx` to keep bundle size lean while providing all chart types used throughout the dashboard.
+
+## Top-Level State
+
+`App.jsx` maintains all shared state via React hooks:
+
+- `theme` – toggles between the `DARK_THEME` and `LIGHT_THEME` palettes, persists to `localStorage`, and synchronises via live updates.
+- `filters` – includes `region`, `year`, and `scenario`. These drive data generation, chart selection, and textual labels.
+- `variant` – a numeric seed passed into the random generator to refresh the mock dataset on demand.
+- `liveState` plus ref helpers – track the status of the optional Server-Sent Events (SSE) connection.
+- `eventSourceRef`, `retryTimeoutRef`, `skipBroadcastRef`, `hasHydratedRef` – mutable refs that manage SSE reconnection logic and prevent echoing incoming updates back to the server.
+
+Two `useEffect` hooks orchestrate side effects:
+
+1. Writing the selected `theme` to the `<html data-theme>` attribute and to `localStorage` for persistence.
+2. Establishing an SSE connection to `/api/stream`, listening for `update` and `sync` events, and broadcasting local changes to `/api/controls` via `fetch` (unless the change originated remotely).
+
+## Data Pipeline
+
+All display metrics are computed at runtime. The pipeline follows three sequential steps whenever `filters`, `variant`, or `theme` change:
+
+1. `generateDashboardData(filters, variant)` produces toxin indices, temperatures, fish biomass, reef conditions, desalination throughput, gas levels, occupancy, energy mix, a site watchlist, incidents, and map intensities.
+2. `buildChartConfigs(data, palette)` converts those numbers into Chart.js datasets and options with colours drawn from the active palette.
+3. `useMemo` caches both results to avoid recomputation unless dependencies change.
+
+`regionLabel` and `scenarioMeta` are derived from static lookups to power UI copy, while `filteredWatchlist` applies an additional filter when a specific region is selected.
+
+## Component Catalogue
+
+Although everything lives inside one file, the code is organised into functional components for clarity:
+
+- **`KpiCard`** – Displays a headline metric with an inline sparkline rendered via Chart.js line charts.
+- **`MapPanel`** – Renders animated bubbles over the textured background map using CSS custom properties.
+- **`Timeline`** – Lists recent incidents with severity pills.
+- **`WatchlistTable`** – Tabular view of sites nearing compliance thresholds with risk badges.
+- **`SimulationControlsPanel`** – Form inputs (selects, range slider, theme toggle, randomiser) used on the `/controls` route.
+- **`ControlsPage`** – Wrapper around the controls panel plus presenter tips.
+- **`DashboardView`** – The main analytics grid containing KPI cards, charts, watchlist, map, and timeline.
+
+Each chart card uses the data produced by `buildChartConfigs`, ensuring colour tokens and axis styling stay in sync with the current theme.
+
+## Routing and Layout
+
+React Router maps `/`, `/controls`, and a wildcard route to either the dashboard or controls view. Layout is composed of three structural areas:
+
+1. **Topbar** – Contains the project title, scenario metadata pills, and live feed indicator.
+2. **Main content** – Renders either the dashboard grid or the controls page within a centred column.
+3. **Footer** – Reiterates that the dataset is fictional and provides a fictitious copyright.
+
+CSS custom properties defined in `styles.css` power both dark and light presentations. The `<html>` element receives a `data-theme` attribute so selectors can swap tokens without rerendering components.
+
+## Live Collaboration
+
+When the hosting environment implements the `/api/stream` SSE endpoint and the `/api/controls` POST endpoint, multiple viewers remain synchronised:
+
+- Incoming SSE messages call `applyRemoteUpdate`, update state, and temporarily disable outbound broadcasts to avoid loops.
+- Disconnections trigger exponential reconnection with a five-second delay.
+- Local state changes issue background POST requests that servers can relay to other dashboard instances.
+
+If SSE is unavailable (detected via feature check), the dashboard gracefully degrades by setting the live indicator to `unsupported` while retaining full local functionality.

--- a/docs/data-scenarios.md
+++ b/docs/data-scenarios.md
@@ -1,0 +1,100 @@
+# Data & Scenario Reference
+
+All analytics in the GOOS Dashboard are derived from `generateDashboardData(filters, variant)` within `src/App.jsx`. The function combines a deterministic pseudo-random generator, baseline constants, and scenario multipliers to produce convincing yet entirely fictional metrics. This reference explains what each dataset represents and how filters influence the outputs.
+
+## Deterministic Randomisation
+
+- `mulberry32(seed)` produces a repeatable stream of floating-point numbers in the range `[0, 1)`.
+- The seed blends the selected year, the `variant` value, and the ASCII code of the scenario string. As a result, identical filter combinations reproduce the same figures even after browser refreshes.
+- The "Randomize Mock Data" button simply updates `variant` to `Date.now()`, forcing a new seed and therefore a fresh data realisation.
+
+## Filters & Scenarios
+
+Three filter groups shape the dataset:
+
+| Filter | Purpose | Impact |
+| --- | --- | --- |
+| `region` | Used for watchlist filtering and labelling. | Does not recalculate data, but controls which rows appear in the compliance table. |
+| `year` | Integer between 2038 and 2042. | Applies gradual drifts (positive or negative) to many metrics to emulate time series evolution. |
+| `scenario` | `baseline`, `mitigation`, or `expansion`. | Adjusts values via multipliers and offsets to paint optimistic or pessimistic narratives. |
+
+Scenario modifiers follow these high-level rules:
+
+- **Baseline** – Uses raw `BASE_DATA` with minor noise.
+- **Mitigation** – Lowers toxins and CO₂, raises fish biomass and reef health, slightly reduces desalination load, increases reclaimed water share.
+- **Rapid Expansion** – Opposite of mitigation: higher toxin scores and CO₂, reduced biomass, heavier desalination dependence, more watchlist alerts.
+
+## Metric Breakdown
+
+The table below summarises the key fields returned by `generateDashboardData`:
+
+| Key | Description | Notes |
+| --- | --- | --- |
+| `toxins.global` | 12-month composite toxin index. | Baseline values (`BASE_DATA.toxinBase`) adjusted by seasonal sine waves, year drift, scenario shifts, and noise. |
+| `toxins.north` | North Atlantic toxin index. | Derived from global values with additional seasonal spikes. |
+| `toxins.tropics` | Tropical Pacific toxin index. | Global baseline minus mitigation offsets and tropical-specific sine noise. |
+| `temps.surface` | Surface water temperatures across four macro regions. | Scenario factor changes amplitude; mitigation slightly cools, expansion warms. |
+| `temps.depth` | 200m depth temperatures. | Smaller drift compared to surface temperatures. |
+| `fish` | Relative biomass percentages for five fishing regions. | Clamped between 58 and 108 to remain realistic. |
+| `reef.healthy` | Share of reef modules in good condition. | Scenario shift ±7–8% plus yearly drift. |
+| `reef.watch` | Modules requiring monitoring. | Calculated against the healthy segment to keep totals near 100%. |
+| `reef.critical` | Modules at risk. | Complements the other reef segments, with caps to stay between 3 and 35%. |
+| `desal` | Monthly desalination throughput (megalitres/day). | Scenario factor ±25 ML plus random wobble, clamped between 160 and 260. |
+| `reclaimed` | Percentage of water recycled. | Slightly increases under mitigation, decreases under expansion. |
+| `gasses.o2` | Dissolved oxygen (mg/L). | Scenario offsets ±0.12 with yearly drift favouring mitigation. |
+| `gasses.co2` | Carbon dioxide (ppm). | Expansion adds ~6 ppm, mitigation removes ~4 ppm, plus yearly increase. |
+| `occupancy.population` | Population (in thousands) across five habitats. | Drift reflects growth or decline with scenario emphasis. |
+| `occupancy.kwh` | kWh per capita. | Expansion increases energy usage; mitigation reduces slightly. |
+| `kpis` | Aggregated toxin, fish, oxygen, and compliance metrics with sparkline history. | Compliance is a composite derived from toxin average, fish average, and scenario adjustments. |
+| `watchlist` | Array of site risk entries. | Base rows from `WATCHLIST_BASE`, recalculated to include toxin/fish/reef values and a qualitative risk label. |
+| `incidents` | Timeline events with severity levels. | Severity reclassified based on scenario (expansion pushes towards `critical`). |
+| `map` | Heatmap points for each ocean region. | Intensities drift with scenario and year, mapping to `calm`, `warning`, or `critical`. |
+| `energyMix` | Array of four energy source shares. | Hard-coded per scenario to narrate the power story. |
+
+## Watchlist Risk Calculation
+
+Each watchlist entry is enriched as follows:
+
+1. Toxin, fish, and reef values are adjusted using scenario multipliers, year drift, and seeded noise.
+2. A risk score is computed: `0.45 * toxin + 0.3 * (100 - fish) + 0.35 * (70 - reef)`.
+3. Risk categories correspond to thresholds: `High` if score > 32, `Moderate` if > 18, otherwise `Watch`.
+
+Selecting a specific `region` filter on the dashboard limits the table to matching entries; `all` shows every row.
+
+## Incident Severity
+
+Baseline incidents include metadata such as `date`, `title`, and `detail`. `generateDashboardData` recalculates the severity tag by:
+
+- Translating the baseline severity (`high`, `medium`) into a numerical base score.
+- Applying a scenario shift (+0.12 for expansion, −0.12 for mitigation) and random noise.
+- Mapping the final score to `critical` (> 0.72), `warning` (> 0.48), or `info`.
+
+## Map Intensities
+
+`MAP_POINTS` store static coordinates and base intensities for six ocean regions. Scenario and year adjustments produce final intensities between 0.2 and 0.98. Thresholds map to qualitative states:
+
+- `critical` for intensity > 0.72,
+- `warning` for intensity > 0.55,
+- `calm` otherwise.
+
+These fields drive both the bubble size and colour class of each overlay element in `MapPanel`.
+
+## KPI Trends
+
+`kpis.trends` holds sparkline sequences for toxins, fish, dissolved oxygen, and compliance. Each sequence is influenced by:
+
+- Average values from the main dataset (e.g., mean fish biomass).
+- Sinusoidal modulation to mimic seasonality.
+- Scenario adjustments to emphasise risk or recovery narratives.
+
+The dashboard displays the current aggregate values alongside these trends in the KPI grid.
+
+## Energy Mix
+
+Energy mix values are scenario-dependent constants:
+
+- **Baseline:** `[38, 24, 30, 8]` — balanced reliance on solar, tidal, thermal, and diesel backup.
+- **Mitigation:** `[42, 28, 26, 4]` — heavier tilt toward renewables with minimal diesel.
+- **Rapid Expansion:** `[32, 26, 28, 14]` — increased diesel usage due to aggressive construction.
+
+Adjust the arrays if your narrative calls for different power assumptions.

--- a/docs/presenter-mode.md
+++ b/docs/presenter-mode.md
@@ -1,0 +1,61 @@
+# Presenter & Collaboration Guide
+
+The GOOS Dashboard was designed to support classroom storytelling where one person narrates while another adjusts filters in real time. This guide explains how to run the `/controls` experience locally and what is required to enable shared control across multiple devices.
+
+## Local Presenter Controls
+
+1. Start the dev server (`npm run dev`) or serve the production build (`npm run preview`).
+2. Open the main dashboard at `http://localhost:5173/` (replace with the URL printed by Vite).
+3. In another browser tab or device, visit `http://localhost:5173/controls`.
+4. Adjust any of the controls:
+   - **Region selector** – Chooses which ocean appears in the watchlist and summary pill.
+   - **Year slider** – Moves the simulated timeline between 2038 and 2042.
+   - **Scenario dropdown** – Switches between Baseline, Mitigation, and Rapid Expansion narratives.
+   - **Randomize Mock Data** – Regenerates the dataset by updating the pseudo-random seed.
+   - **Theme toggle** – Switches between dark and light palettes.
+
+All changes immediately reflect on the main dashboard because both routes share the same React state inside `<App />`.
+
+## Live Synchronisation (Optional)
+
+For multi-device presentations (e.g., instructor laptop driving a projector, student tablet adjusting filters), the app can synchronise state using Server-Sent Events (SSE) and a lightweight POST endpoint.
+
+### Required Endpoints
+
+| Endpoint | Method | Purpose | Expected Payload |
+| --- | --- | --- | --- |
+| `/api/stream` | SSE | Broadcasts remote updates to each dashboard. | Each message contains JSON such as `{ "filters": { ... }, "variant": 123, "theme": "dark", "timestamp": "2024-04-22T18:32:11.812Z" }`. Events are emitted as either `update` or `sync`. |
+| `/api/controls` | POST | Receives local changes and rebroadcasts them to other clients. | Request body is JSON with the same shape as above. Servers can push it to connected SSE clients. |
+
+The repository ships only the front-end; implementing these endpoints is left to the deployment environment. Example options include:
+
+- A small Node/Express or Fastify service that stores the latest payload in memory and rebroadcasts it.
+- A serverless function (Netlify, Vercel, Cloudflare Workers) that relays messages via durable objects or an in-memory channel.
+
+### Connection Lifecycle
+
+- On mount, the app feature-detects `EventSource`. If unavailable, the live indicator reads `Live feed · unsupported` and no network calls are made.
+- When available, the app subscribes to `/api/stream` and sets the live indicator to `connecting`, then `connected` upon success.
+- Incoming messages call `applyRemoteUpdate`, update React state, and temporarily disable outbound broadcasts to avoid infinite loops.
+- Network errors mark the indicator as `reconnecting…` and retry the SSE connection after 5 seconds.
+- Local state changes (`filters`, `variant`, `theme`) issue a background POST to `/api/controls` unless the change originated from a remote message.
+
+### Status Pills
+
+The live indicator in the top bar communicates connection health:
+
+| Status Class | Label | Meaning |
+| --- | --- | --- |
+| `idle` | `Live feed · idle` | Default before any connection attempt. |
+| `connecting` | `Live feed · connecting…` | Opening the SSE connection. |
+| `connected` | `Live feed · connected` or timestamp | Streaming updates successfully. |
+| `disconnected` | `Live feed · reconnecting…` | Connection dropped; retry scheduled. |
+| `unsupported` | `Live feed · unsupported` | Browser lacks SSE support (common on very old or embedded browsers). |
+
+## Presentation Tips
+
+- Share the `/controls` URL with the presenter while keeping `/` on the primary display.
+- Use the scenario blurb and quick tips (right-hand panel on `/controls`) to guide narration.
+- Tap "Randomize Mock Data" between segments to keep the audience engaged with new numbers while preserving coherent trends.
+- Toggle the theme to highlight how the design adapts to different lighting conditions (useful for accessibility discussions).
+- Remind the audience that the data is fictional; both the top bar and footer reiterate this message.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,76 @@
+# Style & Theming Guide
+
+The dashboard's visual identity is controlled entirely via CSS custom properties and utility classes defined in `src/styles.css`. Use this guide to understand how colours, layout, and interactive states are composed so you can confidently retheme or extend the UI.
+
+## Theme Tokens
+
+The root scope defines all colour values and shadows used across components:
+
+| Token | Dark Theme (default) | Purpose |
+| --- | --- | --- |
+| `--app-bg` | Radial gradient anchored top-right | Page background. |
+| `--panel` | `rgba(17, 26, 46, 0.92)` | Background for large panels (`.panel`). |
+| `--card` | `rgba(19, 30, 54, 0.92)` | Background for chart cards (`.card`). |
+| `--border` | `#23345f` | Border colour for panels, cards, tables. |
+| `--text` | `#e6eefc` | Primary text colour. |
+| `--muted` | `#9bb0d1` | Secondary text (captions, labels). |
+| `--grid` | `#1f2b47` | Chart grid lines. |
+| `--accent` | `#22d3ee` | Primary accent (buttons, dataset lines). |
+| `--accent-2` | `#7c3aed` | Secondary accent (surfaces, gradients). |
+| `--ok` | `#10b981` | Positive states. |
+| `--warn` | `#f59e0b` | Warnings. |
+| `--danger` | `#ef4444` | Alerts. |
+| `--shadow` | `0 28px 60px rgba(8, 14, 28, 0.45)` | Soft drop shadow for depth. |
+
+The light theme overrides these tokens via the `:root[data-theme='light']` selector. When the React state changes `theme`, `<html data-theme="light">` is set automatically, causing the overrides to apply without additional JavaScript.
+
+## Layout Structure
+
+- `.app` – Flex container ensuring the footer stays pinned to the bottom.
+- `.topbar` – Sticky header with blurred backdrop, brand section, and metadata pills. The live indicator inherits colour cues from the token set.
+- `.content` – Centres content (`max-width: 1320px`) and applies consistent vertical spacing between panels and grids.
+- `.primary-grid` – Responsive grid for the scenario context and KPI panels.
+- `.cards-grid` – Multi-column grid for the remaining charts, map, timeline, and tables. Cards expand to full width on smaller screens.
+
+Responsive breakpoints adjust padding, grid columns, and card heights at `960px` and `640px` to maintain readability on tablets and phones.
+
+## Panels & Cards
+
+- `.panel` – Used on the scenario overview and controls pages. Includes a subtle gradient overlay (`::after`) to add depth.
+- `.card` – General-purpose container for charts with a radial highlight in the corner.
+- `.card-wide` – Spans two grid columns for the toxin chart and watchlist. Media queries collapse it to single-column on narrow screens.
+- `.map-card` / `.timeline-card` – Ensure the map and timeline take up available vertical space within the grid.
+
+## Typography & Badges
+
+- `.pill` classes display metadata (scenario, region, live status). Additional modifiers (`.danger`, `.warn`, `.live`) set context-specific colours.
+- `.badge.ghost` – Small soft badge used above charts to indicate cadence.
+- `.risk` modifiers (`.risk-high`, `.risk-medium`, `.risk-low`) communicate compliance levels inside the watchlist table.
+- `.kpi-card` – Houses headline metrics with `.kpi-label`, `.kpi-value`, and `.kpi-sparkline` sub-elements. A gradient overlay ties the cards into the rest of the palette.
+
+## Forms & Buttons
+
+Form controls inside `.controls-grid` inherit the theme tokens to stay legible in both modes. Inputs are uppercase labelled for clarity. Buttons (`.btn`, `.btn.secondary`) use gradients and respond to hover with a slight elevation and accent glow.
+
+## Map & Timeline Styling
+
+- `.map` – Sets up the textured background (`--map-image`), gradient fill, and border. Light mode brightens both the gradient and background image.
+- `.map-bubble` – Absolute-positioned elements sized by JavaScript. Colour gradients shift based on status (`calm`, `warning`, `critical`).
+- `.timeline` – Scrollable column with custom scrollbars, while `.timeline-item` cards inherit accent gradients for each entry.
+
+## Tables
+
+`.data-table` styles the compliance watchlist: compact padding, uppercase headers, and row hover highlights. The `.empty` class provides centred, italicised copy when no rows match the selected region.
+
+## Footer
+
+`.footer` completes the layout with a subtle background and border. Light mode swaps the background for a translucent white and adds an upward shadow for separation.
+
+## Customisation Workflow
+
+1. Adjust colour tokens under `:root` and `:root[data-theme='light']` to introduce new brand colours.
+2. Modify gradients or box shadows to change the depth aesthetic.
+3. Extend utility classes (e.g., add `.risk-critical`) as needed—the React components use straightforward class names and will automatically pick up new styles.
+4. For typography changes, update the Google Fonts import at the top of `styles.css` and adjust font sizes within the relevant classes.
+
+Because all thematic decisions are centralised in CSS, no component code needs to change to experiment with new looks.


### PR DESCRIPTION
## Summary
- add a repository-level README with setup instructions, data overview, and customisation guidance
- document the application architecture, data generation, presenter workflow, and style tokens in a dedicated docs/ directory

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*